### PR TITLE
Add check for empty back references when resolving back references for …

### DIFF
--- a/src/AppserverIo/WebServer/Modules/Rewrite/Entities/Rule.php
+++ b/src/AppserverIo/WebServer/Modules/Rewrite/Entities/Rule.php
@@ -270,6 +270,12 @@ class Rule
      */
     protected function resolveConditions(array $backreferences)
     {
+
+        // ATTENTION: This prevents the creation of unresolved filesystem backreferences
+        if (sizeof($backreferences) === 0) {
+            return;
+        }
+
         // Iterate over all conditions and resolve them too
         foreach ($this->sortedConditions as $key => $sortedCondition) {
             // If we got an array we have to iterate over it separately, but be aware they are or-combined


### PR DESCRIPTION
…a rules condition to prevent unresolved filesystem backreferences